### PR TITLE
[DO NOT MERGE] Planning docs moved to personal-inventory repo

### DIFF
--- a/planning/personal-inventory-app/01-product-overview.md
+++ b/planning/personal-inventory-app/01-product-overview.md
@@ -1,0 +1,58 @@
+# 01 — Product Overview
+
+## Problem
+
+Personal belongings are spread across rooms and storage furniture. Finding items, knowing what to restock, tracking how long consumables last, and avoiding expired food or products is difficult without a structured system.
+
+## Solution
+
+An Android app that mirrors how homes are organized: **house → room → container → item**. Users can photograph items, scan barcodes or QR codes, and—for consumables—track purchases, expiry, finish dates, usage duration, and price changes over time.
+
+## Target User
+
+- Homeowners or renters managing one or more properties
+- Users who want offline access and privacy (local-first data)
+- People who restock groceries, cleaning supplies, or toiletries and want usage and cost insights
+
+## Goals
+
+| Goal | How the app addresses it |
+|------|--------------------------|
+| Fast retrieval | Global search, barcode scan-to-find, favorites, recent items, location breadcrumbs |
+| Easy replenishment | Low-stock thresholds, expiring-soon alerts, shopping list, “buy again” from last purchase |
+| Accurate organization | Hierarchical locations with nestable containers (e.g. drawer inside cabinet) |
+| Low friction capture | Scan-first add flow, camera photos, category-aware defaults |
+| Consumable insight | Usage duration per cycle, price-over-time charts, store comparison |
+
+## Non-Goals (Initial Releases)
+
+- Multi-user real-time sync
+- Commercial warehouse / SKU management at scale
+- Integration with retailer online accounts
+- Automatic receipt OCR (future consideration)
+
+## Design Principles
+
+1. **Location is always visible** — Every item shows where it lives (breadcrumb).
+2. **Scan is one tap away** — Primary FAB on browse and search screens.
+3. **Progressive complexity** — Durable items need minimal fields; consumables reveal date/price/expiry fields when toggled.
+4. **Offline-first** — Full functionality without network; optional product lookup when online.
+5. **Sensible defaults** — Today’s date for purchase/finish; currency from settings; expiry prompts for food/medicine categories.
+
+## Entity Summary
+
+| Entity | Description | Example |
+|--------|-------------|---------|
+| House | A property | "Main Home", "Beach Condo" |
+| Room | Area within a house | Kitchen, Garage, Bedroom |
+| Container | Furniture or storage unit | Pantry cabinet, Drawer 2, Plastic bin |
+| Item | A tracked object | Olive oil, AA batteries, Drill |
+| Consumable cycle | One purchase-to-finish period | Bought rice Jan 2, finished Jan 23 |
+| Stock lot | (Optional) Unit with its own expiry | 2 milk cartons, different dates |
+
+## Success Metrics (Post-Launch)
+
+- Time to find an item via scan &lt; 3 seconds
+- Add new item with scan &lt; 30 seconds
+- Users act on expiring-soon notifications within 48 hours
+- Replenishment list reduces “forgot to buy” incidents (qualitative)

--- a/planning/personal-inventory-app/02-architecture.md
+++ b/planning/personal-inventory-app/02-architecture.md
@@ -1,0 +1,164 @@
+# 02 — Architecture
+
+## High-Level Diagram
+
+```mermaid
+flowchart TB
+    subgraph UI["Presentation — Jetpack Compose"]
+        Screens[Screens and Navigation]
+        VM[ViewModels / UiState]
+    end
+
+    subgraph Domain["Domain Layer"]
+        UC[Use Cases]
+        Models[Domain Models]
+    end
+
+    subgraph Data["Data Layer"]
+        Repo[Repositories]
+        Room[(Room SQLite)]
+        Files[Local File Storage]
+    end
+
+    subgraph Platform["Platform Services"]
+        Scanner[ML Kit Barcode Scanner]
+        Camera[CameraX]
+        Work[WorkManager]
+    end
+
+    Screens --> VM --> UC --> Repo
+    Repo --> Room
+    Repo --> Files
+    UC --> Scanner
+    UC --> Camera
+    UC --> Work
+```
+
+## Technology Stack
+
+| Layer | Choice | Rationale |
+|-------|--------|-----------|
+| Language | Kotlin | Modern Android standard |
+| UI | Jetpack Compose | Declarative, fast iteration |
+| Navigation | Navigation Compose | Type-safe routes |
+| Architecture | MVVM + use cases | Clear separation without over-abstraction |
+| DI | Hilt | Standard Google DI |
+| Database | Room + Flow | Reactive, offline, type-safe SQL |
+| Images | Coil | Compose-friendly image loading |
+| Barcode | ML Kit Barcode Scanning | Offline, accurate |
+| Camera | CameraX | Stable preview + analysis pipeline |
+| Charts | Vico or MPAndroidChart | Price and usage visualizations |
+| Background | WorkManager | Expiry and replenishment reminders |
+| Async | Coroutines + Flow | Structured concurrency |
+
+## Package Structure
+
+```
+app/
+├── ui/
+│   ├── browse/          # House → room → container hierarchy
+│   ├── item/            # Detail, add/edit, move
+│   ├── scan/            # Camera scanner screen
+│   ├── search/          # Global search
+│   ├── consumable/      # Insights, price/usage charts
+│   ├── lists/           # Shopping list, expiring soon
+│   └── settings/
+├── domain/
+│   ├── model/
+│   └── usecase/
+├── data/
+│   ├── local/
+│   │   ├── entity/
+│   │   ├── dao/
+│   │   └── InventoryDatabase.kt
+│   └── repository/
+├── di/
+└── util/                # Dates, currency, image compression
+```
+
+Defer multi-module Gradle splits until the codebase grows beyond ~15k LOC.
+
+## Repository Layer
+
+| Repository | Responsibility |
+|------------|----------------|
+| `HouseRepository` | CRUD houses, default house selection |
+| `RoomRepository` | Rooms scoped to house |
+| `ContainerRepository` | Containers, nesting, sort order |
+| `ItemRepository` | Items, photos, search, barcode lookup, location path |
+| `ConsumableRepository` | Cycles, expiry, usage stats, price trends, discard |
+| `ScanRepository` | Scan history, barcode resolution |
+| `ShoppingListRepository` | Restock queue |
+
+## Core Use Cases
+
+| Use Case | Description |
+|----------|-------------|
+| `GetLocationBreadcrumbUseCase` | "Kitchen › Pantry Cabinet › Top Shelf" |
+| `AddItemWithScanUseCase` | Scan → lookup → create or navigate |
+| `MoveItemUseCase` | Change container/room |
+| `StartConsumableCycleUseCase` | Log purchase with price and expiry |
+| `FinishConsumableCycleUseCase` | Set finish date, compute duration |
+| `DiscardConsumableLotUseCase` | Mark expired/wasted stock |
+| `GetExpiringItemsUseCase` | Items expiring within N days |
+| `GetReplenishmentCandidatesUseCase` | Low stock + expiring + usage heuristics |
+| `GetPriceTrendUseCase` | Unit price points over time |
+| `ExportInventoryUseCase` | JSON/CSV backup |
+
+## Domain Models (UI-Facing)
+
+```kotlin
+data class ItemWithLocation(
+    val item: Item,
+    val photos: List<ItemPhoto>,
+    val locationPath: String,
+    val openCycle: ConsumableCycle?,
+    val currentExpiryDate: Long?,
+    val avgUsageDays: Int?,
+    val latestUnitPrice: Double?
+)
+
+data class ConsumableInsights(
+    val cycles: List<ConsumableCycle>,
+    val avgDurationDays: Double,
+    val pricePoints: List<PricePoint>,
+    val priceChangePercent: Double?,
+    val expiredBeforeFinishCount: Int
+)
+
+data class ReplenishmentAlert(
+    val item: Item,
+    val reason: AlertReason,  // LOW_STOCK, EXPIRING_SOON, EXPIRED, USAGE_HEURISTIC
+    val priority: Int,
+    val detail: String
+)
+```
+
+## File Storage
+
+- Photos stored in app-specific storage (`Context.filesDir` or MediaStore for gallery picks)
+- Database stores URI strings only
+- Compress images on save (max ~1920px long edge, JPEG 85%)
+- Receipt photos attached to consumable cycles
+
+## Security and Privacy
+
+- All data local by default
+- No account required for MVP
+- Export/import for user-controlled backup
+- Camera permission requested with rationale screen
+
+## Testing Strategy
+
+| Layer | Focus |
+|-------|-------|
+| DAO | CRUD, cascade deletes, search queries, expiry date filters |
+| Use cases | Cycle duration math, expiry alert rules, price calculations |
+| ViewModel | State transitions on scan result, form validation |
+| UI | Critical flows: add item, scan find, mark finished |
+
+## Future Architecture Extensions
+
+- `sync/` module for cloud backup (Firebase, Drive, or self-hosted)
+- `widget/` for quick scan shortcut
+- OCR module for expiry date extraction from packaging photos

--- a/planning/personal-inventory-app/03-database-schema.md
+++ b/planning/personal-inventory-app/03-database-schema.md
@@ -1,0 +1,265 @@
+# 03 — Database Schema
+
+Room/SQLite schema for hierarchical inventory, consumable lifecycle, expiry, and price tracking.
+
+## ER Diagram
+
+```mermaid
+erDiagram
+    HOUSE ||--o{ ROOM : contains
+    ROOM ||--o{ CONTAINER : contains
+    CONTAINER ||--o{ CONTAINER : nests
+    CONTAINER ||--o{ ITEM : holds
+    ROOM ||--o{ ITEM : holds_unassigned
+    ITEM ||--o{ ITEM_PHOTO : has
+    ITEM ||--o{ CONSUMABLE_CYCLE : tracks
+    ITEM ||--o{ STOCK_LOT : optional_multi_unit
+    ITEM }o--o{ TAG : tagged
+    CONSUMABLE_CYCLE ||--o{ STOCK_LOT : may_create
+    ITEM ||--o{ SCAN_HISTORY : scanned
+```
+
+## Tables
+
+### houses
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | INTEGER PK | Auto-increment |
+| name | TEXT NOT NULL | |
+| address | TEXT | Optional |
+| notes | TEXT | |
+| cover_photo_uri | TEXT | |
+| created_at | INTEGER | Epoch millis |
+| updated_at | INTEGER | |
+
+### rooms
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | INTEGER PK | |
+| house_id | INTEGER FK → houses | ON DELETE CASCADE |
+| name | TEXT NOT NULL | |
+| floor_label | TEXT | e.g. "Ground", "2nd" |
+| notes | TEXT | |
+| photo_uri | TEXT | |
+| sort_order | INTEGER | Default 0 |
+
+### containers
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | INTEGER PK | |
+| room_id | INTEGER FK → rooms | ON DELETE CASCADE |
+| parent_id | INTEGER FK → containers | NULL; nested drawer/shelf |
+| name | TEXT NOT NULL | |
+| type | TEXT NOT NULL | CABINET, DRAWER, SHELF, BOX, BIN, OTHER |
+| description | TEXT | |
+| photo_uri | TEXT | |
+| sort_order | INTEGER | Default 0 |
+
+### items
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | INTEGER PK | |
+| container_id | INTEGER FK → containers | NULL if room-only |
+| room_id | INTEGER FK → rooms | NULL if in container |
+| name | TEXT NOT NULL | |
+| description | TEXT | |
+| category | TEXT | FOOD, CLEANING, TOOLS, MEDICINE, etc. |
+| is_consumable | INTEGER | 0/1 boolean |
+| quantity | REAL | Default 1 |
+| unit | TEXT | pcs, g, ml, pack |
+| min_quantity | REAL | Replenishment threshold |
+| barcode | TEXT | EAN/UPC |
+| qr_payload | TEXT | Raw QR content |
+| brand | TEXT | |
+| is_favorite | INTEGER | 0/1 |
+| current_expiry_date | INTEGER | Denormalized; earliest active lot |
+| created_at | INTEGER | |
+| updated_at | INTEGER | |
+
+**Constraint:** `container_id` OR `room_id` must be set (enforced in DAO/repository).
+
+### item_photos
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | INTEGER PK | |
+| item_id | INTEGER FK → items | ON DELETE CASCADE |
+| uri | TEXT NOT NULL | |
+| is_primary | INTEGER | 0/1 |
+| sort_order | INTEGER | |
+| created_at | INTEGER | |
+
+### consumable_cycles
+
+One row = one purchase through finish (or discard). Source of truth for usage duration and price history.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | INTEGER PK | |
+| item_id | INTEGER FK → items | ON DELETE CASCADE |
+| purchase_date | INTEGER NOT NULL | Epoch millis |
+| finish_date | INTEGER | NULL = still in use |
+| expiry_date | INTEGER | NULL = no expiry |
+| expiry_type | TEXT | USE_BY, BEST_BEFORE, NONE |
+| opened_date | INTEGER | When seal broken |
+| purchase_price | REAL | Total paid |
+| currency | TEXT | Default from settings |
+| quantity_purchased | REAL | |
+| store_name | TEXT | |
+| receipt_photo_uri | TEXT | |
+| notes | TEXT | |
+
+**Computed values (not stored):**
+
+- `duration_days = finish_date - purchase_date` (or `now - purchase_date` if open)
+- `unit_price = purchase_price / quantity_purchased`
+
+### stock_lots (v1.3+)
+
+For multiple units with different expiry dates (e.g. 3 yogurt cups).
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | INTEGER PK | |
+| item_id | INTEGER FK → items | ON DELETE CASCADE |
+| cycle_id | INTEGER FK → consumable_cycles | Optional link to purchase |
+| quantity | REAL NOT NULL | |
+| expiry_date | INTEGER | |
+| expiry_type | TEXT | USE_BY, BEST_BEFORE, NONE |
+| opened_date | INTEGER | |
+| status | TEXT | ACTIVE, FINISHED, DISCARDED |
+| notes | TEXT | |
+| created_at | INTEGER | |
+
+Until v1.3, a single open cycle per item is sufficient for most households.
+
+### tags / item_tags
+
+```sql
+tags (id, name UNIQUE)
+item_tags (item_id, tag_id) — composite PK
+```
+
+### scan_history
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | INTEGER PK | |
+| raw_value | TEXT NOT NULL | |
+| format | TEXT | EAN_13, QR_CODE, etc. |
+| item_id | INTEGER FK → items | NULL if no match |
+| scanned_at | INTEGER | |
+| source | TEXT | ADD_ITEM, SEARCH, RESTOCK |
+
+### shopping_list
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | INTEGER PK | |
+| item_id | INTEGER FK → items | |
+| quantity | REAL | |
+| added_at | INTEGER | |
+| is_checked | INTEGER | 0/1 |
+
+## Indexes
+
+```sql
+CREATE INDEX idx_rooms_house ON rooms(house_id);
+CREATE INDEX idx_containers_room ON containers(room_id);
+CREATE INDEX idx_containers_parent ON containers(parent_id);
+CREATE INDEX idx_items_container ON items(container_id);
+CREATE INDEX idx_items_room ON items(room_id);
+CREATE INDEX idx_items_barcode ON items(barcode);
+CREATE INDEX idx_items_name ON items(name);
+CREATE INDEX idx_items_expiry ON items(current_expiry_date);
+CREATE INDEX idx_cycles_item ON consumable_cycles(item_id);
+CREATE INDEX idx_cycles_dates ON consumable_cycles(purchase_date, finish_date);
+CREATE INDEX idx_cycles_expiry ON consumable_cycles(expiry_date);
+CREATE INDEX idx_lots_item_expiry ON stock_lots(item_id, expiry_date);
+```
+
+## Cascade Rules
+
+- Delete house → rooms → containers → items → photos, cycles, lots
+- Delete item → photos, cycles, lots, shopping list entries, scan history refs (set null or cascade per table)
+
+## Room Entity Example
+
+```kotlin
+@Entity(
+    tableName = "consumable_cycles",
+    foreignKeys = [
+        ForeignKey(
+            entity = ItemEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["itemId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("itemId"), Index("expiryDate")]
+)
+data class ConsumableCycleEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val itemId: Long,
+    val purchaseDate: Long,
+    val finishDate: Long? = null,
+    val expiryDate: Long? = null,
+    val expiryType: String = "USE_BY",
+    val openedDate: Long? = null,
+    val purchasePrice: Double? = null,
+    val currency: String = "USD",
+    val quantityPurchased: Double,
+    val storeName: String? = null,
+    val receiptPhotoUri: String? = null,
+    val notes: String? = null
+)
+```
+
+## Key Queries
+
+### Location breadcrumb
+
+Join item → container (recursive parent) → room → house. Precompute path in repository or use recursive CTE for deep nesting.
+
+### Expiring soon
+
+```sql
+SELECT * FROM items
+WHERE is_consumable = 1
+  AND current_expiry_date IS NOT NULL
+  AND current_expiry_date <= :thresholdMillis
+ORDER BY current_expiry_date ASC;
+```
+
+### Price trend
+
+```sql
+SELECT purchase_date,
+       purchase_price / quantity_purchased AS unit_price,
+       store_name
+FROM consumable_cycles
+WHERE item_id = :itemId AND purchase_price IS NOT NULL
+ORDER BY purchase_date ASC;
+```
+
+### Barcode lookup
+
+```sql
+SELECT * FROM items WHERE barcode = :value OR qr_payload = :value LIMIT 1;
+```
+
+## Migration Strategy
+
+| Version | Change |
+|---------|--------|
+| 1 | Core hierarchy + items + photos |
+| 2 | Consumable cycles, barcode, scan history |
+| 3 | Expiry fields, current_expiry_date on items |
+| 4 | Shopping list, tags |
+| 5 | stock_lots table |
+
+Use Room auto-migrations where possible; test migrations with exported JSON fixtures.

--- a/planning/personal-inventory-app/04-scanning.md
+++ b/planning/personal-inventory-app/04-scanning.md
@@ -1,0 +1,155 @@
+# 04 — Scanning
+
+Barcode and QR code scanning for fast item lookup, add, and restock flows.
+
+## Overview
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant ScanScreen
+    participant CameraX
+    participant MLKit as ML Kit Barcode
+    participant Repo as ItemRepository
+    participant DB as Room
+
+    User->>ScanScreen: Open scanner
+    ScanScreen->>CameraX: Start preview
+    CameraX->>MLKit: Frame analysis
+    MLKit-->>ScanScreen: Barcode detected
+    ScanScreen->>Repo: lookupByBarcode(value)
+    alt Item exists
+        Repo-->>ScanScreen: Item + location path
+        ScanScreen-->>User: Navigate to item detail
+    else Unknown barcode
+        ScanScreen-->>User: Pre-fill Add Item form
+    end
+    ScanScreen->>Repo: logScan(raw, format, itemId?)
+```
+
+## Libraries
+
+| Component | Library |
+|-----------|---------|
+| Camera preview | CameraX |
+| Barcode detection | ML Kit Barcode Scanning |
+| Permissions | Accompanist Permissions or Activity Result API |
+
+ML Kit runs on-device (no network required).
+
+## Supported Formats
+
+- EAN-13, EAN-8
+- UPC-A, UPC-E
+- Code-128, Code-39
+- QR Code
+- Data Matrix (optional)
+
+## Scan Entry Points
+
+| Entry | Behavior |
+|-------|----------|
+| Home FAB | Full-screen scanner; primary global action |
+| Search screen | Toggle scan mode instead of keyboard |
+| Add Item form | "Scan barcode" fills barcode field + optional name lookup |
+| Restock flow | Scan existing item → open purchase log form |
+
+## Scanner Screen UX
+
+1. Camera preview (full screen)
+2. Viewfinder overlay (rounded rect)
+3. Torch toggle (low light)
+4. Manual entry fallback link
+5. Haptic + sound on successful read (configurable)
+6. Debounce: ignore duplicate reads for 2 seconds after match
+
+## Resolution Logic
+
+```
+onBarcodeDetected(value, format):
+  1. log to scan_history
+  2. item = repository.findByBarcodeOrQr(value)
+  3. if item != null:
+       navigate to ItemDetail(item.id)
+     else:
+       navigate to AddItem(prefillBarcode = value, prefillFormat = format)
+```
+
+## Optional Online Product Lookup
+
+When network is available and barcode is unknown:
+
+1. Query Open Food Facts or UPC Item DB
+2. Prefill name, brand, category, image URL
+3. User confirms before save
+4. Cache result locally to avoid repeat API calls
+
+**Never block save on network failure.**
+
+## Permissions Flow
+
+1. User taps Scan
+2. If `CAMERA` not granted → rationale bottom sheet explaining why
+3. System permission dialog
+4. If denied permanently → link to app settings + manual barcode entry
+
+## CameraX Pipeline
+
+```kotlin
+// Pseudocode
+val imageAnalysis = ImageAnalysis.Builder()
+    .setBackpressureStrategy(STRATEGY_KEEP_ONLY_LATEST)
+    .build()
+
+imageAnalysis.setAnalyzer(executor) { imageProxy ->
+    val inputImage = imageProxy.toInputImage()
+  scanner.process(inputImage)
+        .addOnSuccessListener { barcodes ->
+            barcodes.firstOrNull()?.let { handleBarcode(it) }
+        }
+        .addOnCompleteListener { imageProxy.close() }
+}
+```
+
+## Data Stored Per Scan
+
+| Field | Example |
+|-------|---------|
+| raw_value | `5901234123457` |
+| format | `EAN_13` |
+| item_id | `42` or null |
+| scanned_at | epoch millis |
+| source | `SEARCH` |
+
+Useful for audit trail and "recent scans" shortcut.
+
+## Error Handling
+
+| Case | UX |
+|------|-----|
+| No camera | Show message; manual entry only |
+| No barcode in frame | Passive hint: "Point at barcode" |
+| Multiple barcodes | Pick largest / center-most in viewfinder |
+| Damaged barcode | Manual entry + optional photo of label |
+
+## Future: Expiry OCR
+
+Phase 2+ enhancement using ML Kit Text Recognition:
+
+1. User taps "Scan expiry date" on purchase form
+2. Camera captures expiry region on packaging
+3. OCR extracts date string → parse to `expiry_date`
+4. User confirms parsed date
+
+Not required for MVP.
+
+## Testing
+
+- Unit: debounce logic, barcode normalization (leading zeros)
+- Instrumented: mock `BarcodeScanner` with test images
+- Manual: real devices in varied lighting
+
+## Security Notes
+
+- QR payloads may contain URLs — do not auto-open links; show preview first
+- Do not log scans to external analytics without user consent

--- a/planning/personal-inventory-app/05-consumables-expiry-pricing.md
+++ b/planning/personal-inventory-app/05-consumables-expiry-pricing.md
@@ -1,0 +1,203 @@
+# 05 — Consumables, Expiry, and Pricing
+
+Lifecycle tracking for consumable items: purchases, expiry, finish dates, usage duration, price trends, and replenishment.
+
+## Consumable vs Durable
+
+| Type | Fields | Tracking |
+|------|--------|----------|
+| Durable | Name, location, photos, quantity | No cycles |
+| Consumable | + purchase/finish/expiry/price | `consumable_cycles` (+ optional `stock_lots`) |
+
+Toggle `is_consumable` on item create/edit. Category-aware prompts (FOOD, MEDICINE) encourage expiry entry.
+
+## Lifecycle States
+
+```mermaid
+stateDiagram-v2
+    [*] --> Purchased: Log purchase
+    Purchased --> InUse: Default / opened
+    InUse --> Finished: Mark finished
+    InUse --> Discarded: Expired or waste
+    Finished --> Purchased: Restock (new cycle)
+    Discarded --> Purchased: Restock (new cycle)
+```
+
+## Consumable Cycle
+
+One cycle = one purchase episode.
+
+| Field | Purpose |
+|-------|---------|
+| purchase_date | When bought |
+| finish_date | When used up (null = open) |
+| expiry_date | Printed date on package |
+| expiry_type | USE_BY, BEST_BEFORE, NONE |
+| opened_date | Optional; seal broken |
+| purchase_price | Total paid |
+| quantity_purchased | Units or volume |
+| store_name | For price comparison |
+
+### Duration
+
+```
+duration_days = finish_date - purchase_date
+if finish_date is null:
+  duration_so_far = today - purchase_date
+```
+
+Display on item detail:
+
+- **This cycle:** 18 days (Jan 2 → Jan 20)
+- **Average:** 21 days across last N cycles
+- **Estimated run-out:** purchase_date + avg_duration (if cycle open)
+
+## Expiry
+
+### Where expiry lives
+
+| Level | Has expiry? |
+|-------|-------------|
+| Item (catalog) | No |
+| Consumable cycle | Yes — per purchase |
+| Stock lot (v1.3+) | Yes — per physical unit |
+| items.current_expiry_date | Denormalized earliest active expiry |
+
+### Expiry types
+
+| Type | Label | Alert behavior |
+|------|-------|----------------|
+| USE_BY | Use by | Strong warning; mark expired after date |
+| BEST_BEFORE | Best before | Softer "quality may decline" message |
+| NONE | No expiry | No expiry alerts |
+
+### Opened date
+
+Optional field for products with shorter life after opening (sauces, cosmetics). Future rule example:
+
+```
+effective_expiry = min(expiry_date, opened_date + category.open_shelf_life_days)
+```
+
+Defer open-shelf-life rules to v1.3; store `opened_date` in MVP.
+
+### Discard flow
+
+When product expires or is thrown away before finishing:
+
+1. User taps **Discard**
+2. Set lot/cycle status to DISCARDED (or set finish_date with note)
+3. Prompt: add to shopping list / log new purchase
+4. Recompute `current_expiry_date` from remaining active lots
+
+## Price Trends
+
+### Unit price calculation
+
+```
+unit_price = purchase_price / quantity_purchased
+```
+
+### Chart data
+
+Line chart: X = purchase_date, Y = unit_price.
+
+Optional overlays:
+
+- Store name per point
+- % change vs previous purchase
+- Average unit price (horizontal line)
+
+### Insights cards
+
+| Card | Calculation |
+|------|-------------|
+| Avg unit price | Mean of unit_price across cycles |
+| Cheapest store | Store with lowest avg unit_price |
+| Price change | (latest - previous) / previous × 100 |
+| Total spend | Sum of purchase_price over period |
+
+## Replenishment Alerts
+
+Combined priority queue:
+
+| Priority | Reason | Rule |
+|----------|--------|------|
+| 1 | EXPIRED | current_expiry_date &lt; today |
+| 2 | EXPIRING_SOON | expiry within 3 days |
+| 3 | EXPIRING_SOON | expiry within 7 days |
+| 4 | LOW_STOCK | quantity ≤ min_quantity |
+| 5 | USAGE_HEURISTIC | open cycle age &gt; avg_duration × 1.1 |
+
+### Notifications
+
+`WorkManager` daily job:
+
+- "2 items expire this week"
+- "Rice may be running low (day 28 of ~30 avg)"
+
+User configures lead times in Settings (default 7 days).
+
+## Shopping List
+
+- Add from item detail, discard prompt, or low-stock alert
+- Check off in store
+- Checking off optionally opens **Log purchase** pre-filled
+
+## Restock Flow
+
+1. Scan or select item
+2. Form: purchase date, price, quantity, store, **expiry date**, expiry type
+3. Close any previous open cycle (prompt if still open)
+4. Create new `consumable_cycle`
+5. Update `items.quantity` and `items.current_expiry_date`
+6. Remove from shopping list if present
+
+## Stock Lots (v1.3+)
+
+When one purchase includes multiple units with different expiry dates:
+
+```
+Purchase: 3× yogurt
+  → lot A: expiry Jun 10
+  → lot B: expiry Jun 12
+  → lot C: expiry Jun 15
+```
+
+`current_expiry_date` = earliest ACTIVE lot expiry (Jun 10).
+
+Consuming one unit decrements lot quantity; when zero, mark lot FINISHED.
+
+## Analytics: Expiry vs Usage
+
+Optional insight metrics:
+
+- **Finished before expiry %** — good stewardship
+- **Discarded expired count** — waste tracking
+- **Avg days before expiry when finished** — purchase sizing feedback
+
+## Repository API
+
+```kotlin
+interface ConsumableRepository {
+    suspend fun startCycle(itemId: Long, data: NewCycleData): Long
+    suspend fun finishCycle(cycleId: Long, finishDate: Long)
+    suspend fun discardCycle(cycleId: Long, reason: String?)
+    suspend fun getOpenCycle(itemId: Long): ConsumableCycle?
+    suspend fun getUsageStats(itemId: Long): UsageStats
+    suspend fun getPriceTrend(itemId: Long): List<PricePoint>
+    suspend fun getExpiringItems(withinDays: Int): List<ItemWithLocation>
+    suspend fun getExpiredItems(): List<ItemWithLocation>
+    suspend fun recomputeCurrentExpiry(itemId: Long)
+}
+```
+
+## Edge Cases
+
+| Case | Handling |
+|------|----------|
+| New purchase before old finished | Prompt: finish/discard old cycle first |
+| No expiry entered for food | Soft warning; allow save |
+| min_quantity not set | Skip low-stock alert; usage heuristic only |
+| Non-consumable with barcode | No cycle UI shown |
+| Currency change | Store per-cycle currency; convert in UI if needed (v2) |

--- a/planning/personal-inventory-app/06-ui-flows.md
+++ b/planning/personal-inventory-app/06-ui-flows.md
@@ -1,0 +1,253 @@
+# 06 — UI Flows
+
+Navigation structure, screen inventory, and key user journeys.
+
+## Navigation Map
+
+```mermaid
+flowchart LR
+    Home[Home / Houses]
+    House[House Detail]
+    Room[Room Detail]
+    Container[Container Detail]
+    Item[Item Detail]
+    Search[Global Search]
+    Scan[Scanner]
+    Lists[Lists]
+    Insights[Consumable Insights]
+
+    Home --> House --> Room --> Container --> Item
+    Room --> Item
+    Home --> Search
+    Home --> Scan
+    Home --> Lists
+    Item --> Insights
+```
+
+## Bottom Navigation (4 Tabs)
+
+| Tab | Icon | Content |
+|-----|------|---------|
+| Browse | Home | House list → hierarchy drill-down |
+| Search | Search | Text search + filter chips + scan toggle |
+| Scan | Camera | Full-screen scanner (center, emphasized) |
+| Lists | List | Expiring soon, shopping list, low stock |
+
+FAB on Browse: quick **Add Item**.
+
+## Screen Inventory
+
+| Screen | Route | Purpose |
+|--------|-------|---------|
+| Onboarding | `/onboarding` | First house + template rooms |
+| Houses | `/houses` | All properties |
+| House detail | `/house/{id}` | Room grid/list |
+| Room detail | `/room/{id}` | Containers + unassigned items |
+| Container detail | `/container/{id}` | Nested containers + items |
+| Item detail | `/item/{id}` | Photos, metadata, consumable panel |
+| Add/Edit item | `/item/add`, `/item/{id}/edit` | Form + scan + photos |
+| Location picker | bottom sheet | House → room → container breadcrumb |
+| Scanner | `/scan` | Camera barcode/QR |
+| Search results | `/search` | Query + filters |
+| Lists hub | `/lists` | Alerts and shopping |
+| Consumable insights | `/item/{id}/insights` | Charts and cycle history |
+| Settings | `/settings` | Currency, alert lead time, export |
+
+## Visual Patterns
+
+### Location breadcrumb
+
+Every item row and detail header shows muted path:
+
+```
+Main Home › Kitchen › Pantry Cabinet › Top Shelf
+```
+
+Tappable segments navigate up the hierarchy.
+
+### Item list row
+
+```
+[photo]  Item Name                    ♥
+         Kitchen › Drawer 2          [Consumable badge]
+         Expires in 3 days           [if applicable]
+```
+
+### Status badges (consumables)
+
+| Badge | Color semantics |
+|-------|-----------------|
+| OK | Neutral |
+| Soon | Warning (≤7 days) |
+| Expired | Error |
+
+## Flow A: First-Time Onboarding
+
+```mermaid
+flowchart TD
+    A[Welcome] --> B[Name your house]
+    B --> C[Add rooms from templates]
+    C --> D[Optional: skip containers]
+    D --> E[Home — empty state]
+    E --> F[Scan your first item CTA]
+```
+
+Template rooms: Kitchen, Bedroom, Bathroom, Garage, Living Room, Office.
+
+## Flow B: Add Item (Scan-First)
+
+1. Tap **+** or Scan tab
+2. Scan barcode **or** choose "Enter manually"
+3. **If barcode matches existing item** → Item detail
+4. **If new:**
+   - Name (API prefill if online)
+   - Toggle **Consumable**
+   - Take photo(s)
+   - Pick location via hierarchical picker
+   - If consumable: purchase date, price, quantity, **expiry date**, expiry type
+5. Save → success snackbar with location path
+
+### Location picker (bottom sheet)
+
+```
+House:  [Main Home        ▼]
+Room:   [Kitchen          ▼]
+Container: [Pantry Cabinet ▼]
+          [+ New container]
+```
+
+Allow saving to room only (skip container).
+
+## Flow C: Find Item Quickly
+
+| Method | Steps |
+|--------|-------|
+| Scan | Scan → item detail → "Show location" highlights container |
+| Search | Type name/brand/tag → results with location chips |
+| Favorites | Home section — pinned items |
+| Recent | Last 10 viewed |
+| Filter | House, room, category, consumable only |
+
+### Item detail actions
+
+- Edit
+- Move (location picker)
+- Add to favorites
+- Add to shopping list
+- **Mark finished** (consumable)
+- **Discard** (consumable, expired)
+- **Log new purchase** (restock)
+- View insights (consumable)
+
+## Flow D: Consumable Finish & Restock
+
+### Mark finished
+
+1. Open consumable item
+2. Tap **Mark as finished**
+3. Confirm finish date (default today)
+4. Show duration vs average
+5. Dialog: "Add to shopping list?" / "Log new purchase now?"
+
+### Log new purchase
+
+1. Pre-filled item, location, barcode
+2. Purchase date, price, quantity, store
+3. **Expiry date** + type (prominent for FOOD/MEDICINE)
+4. Optional opened date, receipt photo
+5. Save → new cycle, update quantity and current_expiry
+
+## Flow E: Lists Hub
+
+Two sections with tab or segmented control:
+
+### Expiring & expired
+
+Sorted by expiry ascending.
+
+```
+⚠ Expired
+  Milk — expired yesterday — Fridge
+
+⏳ Expiring soon
+  Yogurt — 2 days — Fridge › Top shelf
+  Medicine — 5 days — Bathroom › Cabinet
+```
+
+Swipe actions: Discard, Add to shopping list.
+
+### Shopping list
+
+```
+☐ Rice (1 bag)
+☐ Olive oil (1)
+☑ Batteries (checked — optionally log purchase)
+```
+
+## Flow F: Consumable Insights
+
+Access from item detail (consumables only).
+
+**Sections:**
+
+1. **Summary cards** — avg usage days, avg unit price, price change %
+2. **Usage chart** — bar chart of cycle durations
+3. **Price chart** — line chart of unit price over time
+4. **Expiry timeline** — purchase → expiry → finish per cycle
+5. **History list** — all cycles, tap to expand
+
+## Flow G: Move Item
+
+1. Long-press item **or** Move from detail
+2. Location picker
+3. Confirm → update `container_id` / `room_id`
+4. Snackbar with undo (5 seconds)
+
+## Empty States
+
+| Screen | CTA |
+|--------|-----|
+| No houses | "Add your first house" |
+| No rooms | "Add a room" |
+| No containers | "Add a cabinet or drawer" |
+| No items | "Scan your first item" |
+| No expiring | "Nothing expiring soon" |
+| Empty shopping list | "Add from low stock or item detail" |
+
+## Settings
+
+| Setting | Default |
+|---------|---------|
+| Default house | First created |
+| Currency | Locale-based |
+| Expiry alert lead time | 7 days |
+| Low stock notifications | On |
+| Expiry notifications | On |
+| Haptic on scan | On |
+| Export / Import | JSON file |
+| Theme | System |
+
+## Accessibility
+
+- Location paths readable by TalkBack as full sentence
+- Minimum 48dp touch targets
+- Color-blind safe badge icons (not color alone)
+- Date pickers support TalkBack announcements
+
+## Compose Screen Stubs (Routes)
+
+```kotlin
+sealed class Screen(val route: String) {
+    data object Houses : Screen("houses")
+    data class HouseDetail(val id: Long) : Screen("house/{id}")
+    data class RoomDetail(val id: Long) : Screen("room/{id}")
+    data class ContainerDetail(val id: Long) : Screen("container/{id}")
+    data class ItemDetail(val id: Long) : Screen("item/{id}")
+    data object AddItem : Screen("item/add?barcode={barcode}")
+    data object Scan : Screen("scan")
+    data object Search : Screen("search?q={q}")
+    data object Lists : Screen("lists")
+    data class Insights(val itemId: Long) : Screen("item/{id}/insights")
+    data object Settings : Screen("settings")
+}
+```

--- a/planning/personal-inventory-app/07-build-phases.md
+++ b/planning/personal-inventory-app/07-build-phases.md
@@ -1,0 +1,222 @@
+# 07 — Build Phases
+
+Phased delivery plan with scope, acceptance criteria, and dependencies.
+
+## Phase Overview
+
+```mermaid
+gantt
+    title Delivery Phases
+    dateFormat X
+    axisFormat %s
+
+    section MVP
+    Hierarchy CRUD           :0, 1
+    Items photos search      :1, 2
+
+    section v1.1
+    Barcode scanning         :2, 3
+
+    section v1.2
+    Consumables cycles       :3, 4
+    Expiry and alerts        :4, 5
+
+    section v1.3
+    Price trends             :5, 6
+    Shopping list            :6, 7
+    Stock lots               :7, 8
+
+    section v2
+    Cloud sync export        :8, 9
+```
+
+*Timeline is ordinal, not calendar.*
+
+---
+
+## Phase 0 — Project Setup
+
+**Scope**
+
+- Kotlin + Compose + Hilt + Room skeleton
+- Navigation graph
+- Theme, typography, bottom nav shell
+- Empty database v1 migration
+
+**Done when**
+
+- App launches to empty Houses screen
+- CI runs unit tests
+
+---
+
+## MVP — Hierarchy & Items
+
+**Scope**
+
+- House, room, container CRUD (no nesting yet or simple nesting)
+- Item CRUD with single/multiple photos
+- Location breadcrumb
+- Local text search (name, description, brand)
+- Favorites and recent items
+- Onboarding (first house + rooms)
+
+**Out of scope**
+
+- Barcode, consumables, notifications
+
+**Acceptance criteria**
+
+- [ ] Create house → rooms → container → item with photo
+- [ ] Search finds item by name
+- [ ] Item detail shows full location path
+- [ ] Move item between containers
+- [ ] Data persists across app restart
+
+---
+
+## v1.1 — Scanning
+
+**Scope**
+
+- CameraX + ML Kit scanner screen
+- Barcode field on add/edit item
+- Scan-to-find (existing item)
+- Scan-to-add (unknown barcode → pre-filled form)
+- Scan history table
+- Manual barcode entry fallback
+
+**Acceptance criteria**
+
+- [ ] Scan known barcode opens item detail in &lt;2s after detection
+- [ ] Unknown barcode opens add form with code filled
+- [ ] Scanner works offline
+- [ ] Camera permission rationale shown before request
+
+**Depends on:** MVP
+
+---
+
+## v1.2 — Consumables, Expiry & Alerts
+
+**Scope**
+
+- `is_consumable` toggle and cycle CRUD
+- Purchase date, finish date, duration display
+- Expiry date + expiry type (USE_BY, BEST_BEFORE, NONE)
+- Opened date (optional)
+- `current_expiry_date` denormalization
+- Mark finished / discard flows
+- Lists tab: expiring soon + expired sections
+- WorkManager daily expiry notifications
+- Restock = new cycle
+
+**Acceptance criteria**
+
+- [ ] Log purchase with expiry on consumable item
+- [ ] Item detail shows "Expires in X days" badge
+- [ ] Expired items appear in Lists tab
+- [ ] Notification fires for item expiring within lead time
+- [ ] Finish cycle computes and displays duration
+- [ ] Discard removes from active expiry alerts
+
+**Depends on:** v1.1 (scan aids restock)
+
+---
+
+## v1.3 — Pricing, Shopping & Multi-Lot
+
+**Scope**
+
+- Purchase price, store, unit price calculation
+- Price trend line chart per consumable
+- Usage duration bar chart
+- Shopping list (add, check off)
+- Low-stock alerts (`min_quantity`)
+- Usage-based replenishment heuristic
+- `stock_lots` for multiple expiry per item
+- Export/import JSON backup
+
+**Acceptance criteria**
+
+- [ ] Price chart shows unit price per purchase date
+- [ ] Shopping list add from item detail and alerts
+- [ ] Low-stock item appears in Lists when quantity ≤ min
+- [ ] Two lots with different expiry show earliest on item row
+- [ ] Export and re-import restores full hierarchy
+
+**Depends on:** v1.2
+
+---
+
+## v2 — Platform & Polish
+
+**Scope**
+
+- Container nesting UI polish
+- Optional product API lookup (Open Food Facts)
+- Home screen widget (scan shortcut)
+- Expiry OCR from packaging photo
+- Cloud backup (Drive or Firebase)
+- Multi-household sharing (stretch)
+
+**Acceptance criteria**
+
+- [ ] Product name prefilled from barcode when online
+- [ ] Widget opens scanner
+- [ ] Backup syncs photos + database
+
+---
+
+## Cross-Phase Quality Bar
+
+| Area | Requirement |
+|------|-------------|
+| Performance | Search results &lt;200ms for 5k items |
+| Offline | All core flows work in airplane mode |
+| Rotation | Form state survives configuration change |
+| Deletes | Cascade delete verified in DAO tests |
+| Images | No OOM on 10+ photos per item (paging + compression) |
+
+---
+
+## Risk Register
+
+| Risk | Mitigation |
+|------|------------|
+| Camera fragmentation | CameraX + fallback manual entry |
+| Expiry not on barcode | Manual date picker; OCR in v2 |
+| Deep container nesting UX | Limit UI depth to 3 levels; show full path |
+| Database growth (photos) | Compression + optional "store in gallery" |
+| Scope creep | Strict phase gates; consumable features isolated in module |
+
+---
+
+## Suggested First Implementation Sprint
+
+If starting development now, build in this order:
+
+1. Room entities: houses, rooms, containers, items, item_photos
+2. Houses → Room → Container → Item navigation
+3. Add item with photo + location picker
+4. Search + favorites
+5. Consumable cycles + expiry (before scanning if pantry-first use case)
+6. Scanner integration
+
+Adjust order if barcode-first capture is the top priority.
+
+---
+
+## Document Maintenance
+
+When implementation diverges from these docs:
+
+1. Update the relevant planning doc
+2. Note change in this file under **Changelog**
+
+### Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-07-08 | Initial planning docs created |
+| 2026-07-08 | Added expiry date support to consumable cycles |

--- a/planning/personal-inventory-app/README.md
+++ b/planning/personal-inventory-app/README.md
@@ -1,0 +1,35 @@
+# Personal Inventory Android App — Planning Docs
+
+Design documentation for an offline-first Android application to manage household inventory across a hierarchical location model, with barcode scanning, consumable lifecycle tracking, expiry management, and price trend analytics.
+
+## Document Index
+
+| Doc | Description |
+|-----|-------------|
+| [01-product-overview.md](./01-product-overview.md) | Goals, users, scope, and design principles |
+| [02-architecture.md](./02-architecture.md) | Tech stack, layers, modules, and platform services |
+| [03-database-schema.md](./03-database-schema.md) | Room entities, relationships, indexes, and migrations |
+| [04-scanning.md](./04-scanning.md) | Barcode/QR scanning pipeline and integration points |
+| [05-consumables-expiry-pricing.md](./05-consumables-expiry-pricing.md) | Cycles, expiry, usage duration, price trends, replenishment |
+| [06-ui-flows.md](./06-ui-flows.md) | Navigation, screens, and key user journeys |
+| [07-build-phases.md](./07-build-phases.md) | Phased delivery plan and acceptance criteria |
+
+## Hierarchy Model
+
+```
+House
+ └── Room
+      └── Container (cabinet, drawer, shelf, box — nestable)
+           └── Item (with photos, barcode, optional consumable data)
+```
+
+## Quick Reference
+
+- **Stack:** Kotlin, Jetpack Compose, Room, Hilt, CameraX, ML Kit
+- **Architecture:** MVVM + use cases, repository pattern
+- **Consumable expiry:** Per purchase cycle (optional stock lots in v1.3+)
+- **Primary actions:** Browse, Search, Scan, Lists (shopping + alerts)
+
+## Status
+
+Planning only — no implementation in this repository.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Closed — planning docs moved to standalone Android repo

Planning documentation for the Personal Inventory app now lives in the **`personal-inventory`** standalone project under `planning/`.

Do **not** merge this into the blog repo.

Follow `REPO_SETUP.md` on branch `personal-inventory` to publish `Ezral/personal-inventory`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76df0beb-c67a-444c-8090-2ec96ba552f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76df0beb-c67a-444c-8090-2ec96ba552f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

